### PR TITLE
Review ch2 1

### DIFF
--- a/Chapter02/hello.json
+++ b/Chapter02/hello.json
@@ -1,33 +1,41 @@
 {
-    "builders": [{
-        "type": "virtualbox-iso",
-        "boot_command": ["<esc><wait>", "vmlinuz initrd=initrd.img ", "inst.ks=https://github.com/jboero/hashistack/raw/master/http/ks-centosStreams.cfg", "<enter>"],
-        "boot_wait": "3s",
-        "communicator": "ssh",
-        "cpus": 4,
-        "disk_size": 100000,
-        "guest_additions_mode": "attach",
-        "guest_additions_sha256": "62a0c6715bee164817a6f58858dec1d60f01fd0ae00a377a75bbf885ddbd0a61",
-        "guest_additions_url": "https://download.virtualbox.org/virtualbox/6.1.10/VBoxGuestAdditions_6.1.10.iso",
-        "guest_os_type": "RedHat_64",
-        "headless": true,
-        "iso_checksum": "sha256:39a562c1ea8156b84608fee7f9879ac5566db6b16d8d6a570bbde9a37564745d",
-        "iso_url": "file:///aux/iso/CentOS-Stream-9-latest-x86_64-dvd1.iso",
-        "memory": 8192,
-        "pause_before_connecting": "10s",
-        "shutdown_command": "shutdown -P now",
-        "ssh_username": "root",
-        "ssh_password": "packer",
-        "ssh_timeout": "20m",
-        "vm_name": "hello-world",
-        "vboxmanage": [
-            ["modifyvm", "{{.Name}}", "--paravirtprovider", "kvm"]
-        ]
-    }],
-    "provisioners": [{
-        "type": "file",
-        "destination": "/etc/motd",
-        "direction": "upload",
-        "source": "motd"
-    }]
+  "builders": [
+    {
+      "name": "hello-base",
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "<esc><wait>",
+        "vmlinuz initrd=initrd.img ",
+        "inst.ks=https://github.com/jboero/hashistack/raw/master/http/ks-centosStreams.cfg",
+        "<enter>"
+      ],
+      "boot_wait": "3s",
+      "communicator": "ssh",
+      "cpus": 2,
+      "disk_size": 100000,
+      "guest_additions_mode": "attach",
+      "guest_additions_sha256": "62a0c6715bee164817a6f58858dec1d60f01fd0ae00a377a75bbf885ddbd0a61",
+      "guest_additions_url": "https://download.virtualbox.org/virtualbox/6.1.10/VBoxGuestAdditions_6.1.10.iso",
+      "guest_os_type": "RedHat_64",
+      "headless": false,
+      "iso_checksum": "file:https://lon.mirror.rackspace.com/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-dvd1.iso.SHA256SUM",
+      "iso_url": "https://lon.mirror.rackspace.com/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-dvd1.iso",
+      "memory": 1024,
+      "output_filename": "hello-world.ovf",
+      "pause_before_connecting": "10s",
+      "shutdown_command": "shutdown -P now",
+      "ssh_username": "root",
+      "ssh_password": "packer",
+      "ssh_timeout": "20m",
+      "vm_name": "hello-world"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "destination": "/etc/motd",
+      "direction": "upload",
+      "source": "motd"
+    }
+  ]
 }

--- a/Chapter02/hello.pkr.hcl
+++ b/Chapter02/hello.pkr.hcl
@@ -29,10 +29,10 @@ source "virtualbox-iso" "hello-base" {
 
 // Define a build with our single source builder and one provisioner.
 build {
- sources = ["source.virtualbox-iso.hello-base"]
- provisioner "file" {
-   destination = "/etc/motd"
-   direction   = "upload"
-   content     = "Hello world from Packer."
- }
+  sources = ["source.virtualbox-iso.hello-base"]
+  provisioner "file" {
+    destination = "/etc/motd"
+    direction   = "upload"
+    content     = "Hello world from Packer."
+  }
 }

--- a/Chapter02/hello.pkr.hcl
+++ b/Chapter02/hello.pkr.hcl
@@ -33,6 +33,6 @@ build {
   provisioner "file" {
     destination = "/etc/motd"
     direction   = "upload"
-    content     = "Hello world from Packer."
+    source      = "motd"
   }
 }

--- a/Chapter02/hello.pkr.hcl
+++ b/Chapter02/hello.pkr.hcl
@@ -5,16 +5,16 @@ source "virtualbox-iso" "hello-base" {
   boot_command            = ["<esc><wait>", "vmlinuz initrd=initrd.img ", "inst.ks=https://github.com/jboero/hashistack/raw/master/http/ks-centosStreams.cfg", "<enter>"]
   boot_wait               = "3s"
   communicator            = "ssh"
-  cpus                    = 4
+  cpus                    = 2
   disk_size               = 100000
   guest_additions_mode    = "attach"
   guest_additions_sha256  = "62a0c6715bee164817a6f58858dec1d60f01fd0ae00a377a75bbf885ddbd0a61"
   guest_additions_url     = "https://download.virtualbox.org/virtualbox/6.1.10/VBoxGuestAdditions_6.1.10.iso"
   guest_os_type           = "RedHat_64"
-  headless                = true
-  iso_checksum            = "sha256:5af0d4535a13e8b1c5129df85f6e8c853f0a82f77d8614d4f91187bc7aa94d52"
-  iso_url                 = "http://lon.mirror.rackspace.com/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-dvd1.iso"
-  memory                  = 8192
+  headless                = false
+  iso_checksum            = "file:https://lon.mirror.rackspace.com/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-dvd1.iso.SHA256SUM"
+  iso_url                 = "https://lon.mirror.rackspace.com/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-dvd1.iso"
+  memory                  = 1024
   output_filename         = "hello-world.ovf"
   pause_before_connecting = "10s"
   shutdown_command        = "shutdown -P now"

--- a/Chapter02/hello.pkr.hcl
+++ b/Chapter02/hello.pkr.hcl
@@ -23,7 +23,7 @@ source "virtualbox-iso" "hello-base" {
   ssh_timeout             = "20m"
   vm_name                 = "hello-world"
   vboxmanage = [
-      [ "modifyvm", "{{.Name}}", "--paravirtprovider=kvm" ],
+    #[ "modifyvm", "{{.Name}}", "--paravirtprovider=kvm" ],
  ]
 }
 

--- a/Chapter02/hello.pkr.hcl
+++ b/Chapter02/hello.pkr.hcl
@@ -27,7 +27,7 @@ source "virtualbox-iso" "hello-base" {
  ]
 }
 
-// Define a build with our single source builder and two provisioners.
+// Define a build with our single source builder and one provisioner.
 build {
  sources = ["source.virtualbox-iso.hello-base"]
  provisioner "file" {


### PR DESCRIPTION
Changes:
- Decreased num CPUs to 2
- Use headless false to simplify troubleshooting
- Decrease memory to 1GB
- Use https to load ISO
- Use URL to load checksum
- Comment out paravirtprovider=kvm, most readers will not run Linux
- Fix comment
- Fix formatting
- Align HCL with json provisioning
- Align with json with HCL2 version