### PR TITLE
Ch 07 Fix build_all.sh

### DIFF
--- a/Chapter07/build_all.sh
+++ b/Chapter07/build_all.sh
@@ -8,12 +8,12 @@ function build_dir()
     pushd "$1"
     if [ "build.pkr.hcl" -nt ".build_timestamp" ]
     then
-        packer build "$1" && touch ".build_timestamp" || return 1
+        packer build "." && touch ".build_timestamp" || return 1
     else
         echo "SKIP ${PWD}/build.pkr.hcl not modified since last successful build."
     fi
 
-    find . -type d -maxdepth 1 | xargs build_dir
+    find . -maxdepth 1 -type d | xargs build_dir
     popd
 }
 

--- a/Chapter07/docker_example/build.pkr.hcl
+++ b/Chapter07/docker_example/build.pkr.hcl
@@ -27,12 +27,12 @@ build {
     inline = ["pzstd ./*.tar"]
   }
 
-  post-processors {
-    post-processor "docker-tag" {
+  // post-processors {
+  //  post-processor "docker-tag" {
       // Use the DOCKER_REGISTRY from common.hcl
-      repository =  "${var.DOCKER_REGISTRY}/${source.name}"
-      tags = [var.IMAGE_VERSION]
-    }
-    post-processor "docker-push" {}
-  }
+  //    repository =  "${var.DOCKER_REGISTRY}/${source.name}"
+  //    tags = [var.IMG_VERSION]
+  //  }
+  //  post-processor "docker-push" {}
+  //}
 }


### PR DESCRIPTION
Also docker build fails with

```
==> docker.base_ubuntu: Running post-processor:  (type shell-local)
==> docker.base_ubuntu (shell-local): Running local shell script: /tmp/packer-shell2172979409
==> docker.base_ubuntu (shell-local): ./image.tar          : 29.37%   (190354432 => 55915198 bytes, ./image.tar.zst)
==> docker.base_ubuntu: Running post-processor:  (type docker-tag)
Build 'docker.base_ubuntu' errored after 46 seconds 865 milliseconds: 1 error(s) occurred:

* Post-processor failed: Unknown artifact type: packer.docker
Can only tag from Docker builder artifacts.

==> Wait completed after 46 seconds 865 milliseconds

==> Some builds didn't complete successfully and had errors:
--> docker.base_ubuntu: 1 error(s) occurred:

* Post-processor failed: Unknown artifact type: packer.docker
Can only tag from Docker builder artifacts.

==> Builds finished but no artifacts were created.
+ return 1
```